### PR TITLE
[WIP] - Refactor

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -1,51 +1,51 @@
 const router = require("express").Router();
 const issues = require("../issuesAndStories");
 
+const newIssue = async issue => {
+  const newStory = await issues.createStory(issue);
+  const updatedIssue = await issues.updateIssueTitle(
+    issue.url,
+    issue.title,
+    newStory.id
+  );
+};
+
+const successResponse = (res, code = 200) =>
+  res.status(code).json({ message: "success" });
+
+const closeIssue = async issue => {
+  const title = issue.title.match(/\[[^\]]*\]/g)[0];
+  const storyID = title.substring(1, title.length - 1);
+  await issues.closeStory(storyID);
+};
+
 router.post("/log-payload", (req, res) => {
   const { issue, action } = req.body;
-
+  // console.log(req.body);
+  // console.log(issue, action);
   res.json({ title: "success" });
 });
 
-router.post("/create-story-from-issue", async (req, res) => {
+router.post("/handle-issues", async (req, res) => {
   const { issue, action } = req.body;
 
-  if (action === "opened") {
-    try {
-      const newStory = await issues.createStory(issue);
-      console.log(newStory);
-
-      const updatedIssue = await issues.updateIssueTitle(
-        issue.url,
-        issue.title,
-        newStory.id
-      );
-      console.log(updatedIssue);
-      res.status(200).json({ message: "success" });
-    } catch (err) {
-      console.log(err);
-      res.status(500).json({ message: err });
+  try {
+    switch (action) {
+      case "opened":
+        await newIssue(issue);
+        successResponse(res, 201);
+        break;
+      case "closed":
+        await closeIssue(issue);
+        successResponse(res);
+        break;
+      default:
+        console.log("no action taken");
+        res.status(200).json({ message: "no action taken" });
     }
-  } else {
-    res.status(200).json({ message: "no action taken" });
-  }
-});
-
-router.post("/finish-story", async (req, res) => {
-  const { issue, action } = req.body;
-
-  if (action === "closed") {
-    try {
-      const title = issue.title.match(/\[[^\]]*\]/g)[0];
-      const storyID = title.substring(1, title.length - 1);
-      await issues.closeStory(storyID);
-      res.status(200).json({ message: "success" });
-    } catch (err) {
-      console.log(err);
-      res.status(500).json({ message: err });
-    }
-  } else {
-    res.status(200).json({ message: "no action taken" });
+  } catch (err) {
+    console.log(err);
+    res.status(500).json({ message: err });
   }
 });
 


### PR DESCRIPTION
@antoniojgage @eamoses 

in the attached commit, I've reduced things down to a single `issues` endpoint. This is strictly a proposal atm.

The GH webhook **issues** event listener support the following events: 

_opened, edited, closed, reopened, assigned, unassigned, labeled, unlabeled, milestoned, or demilestoned._

Not saying we'll perform an action on all of these events, but i'm thinking that we can use a `switch` statement to handle incoming events.

Curious to hear your thoughts. 
